### PR TITLE
fix(frontend): replace Bootstrap mobile menu with React state toggle

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,12 +4,37 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { useNotifications } from '@/lib/contexts/NotificationContext';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export default function Header() {
     const { user, isLoading, logout } = useAuth();
     const { unreadCount } = useNotifications();
     const [searchQuery, setSearchQuery] = useState('');
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const [isProfileDropdownOpen, setIsProfileDropdownOpen] = useState(false);
+    const dropdownRef = useRef<HTMLLIElement>(null);
+
+    // Close profile dropdown when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsProfileDropdownOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    // Close mobile menu on route change (resize)
+    useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth >= 1024) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
     return (
         <header className="flex-shrink-0">
@@ -18,7 +43,7 @@ export default function Header() {
                 <nav className="navbar navbar-expand-lg">
                     <div className="container-fluid">
                         {/* Brand */}
-                        <Link href="/" className="navbar-brand d-flex align-items-center text-white" data-aos="fade-right" data-aos-duration="600">
+                        <Link href="/" className="navbar-brand d-flex align-items-center text-white">
                             <div className="brand-logo-container me-2 position-relative" style={{ width: '40px', height: '40px' }}>
                                 <Image
                                     src="/logo.png"
@@ -32,14 +57,24 @@ export default function Header() {
                             <span className="fw-semibold">SocialTechsy</span>
                         </Link>
 
-                        {/* Mobile Toggle */}
-                        <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent">
+                        {/* Mobile Toggle - React controlled */}
+                        <button
+                            className="navbar-toggler"
+                            type="button"
+                            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                            aria-expanded={isMobileMenuOpen}
+                            aria-label="Toggle navigation"
+                        >
                             <span className="navbar-toggler-icon"></span>
                         </button>
 
-                        <div className="collapse navbar-collapse" id="navbarContent">
+                        <div
+                            className={`navbar-collapse ${isMobileMenuOpen ? 'show' : 'collapse'}`}
+                            id="navbarContent"
+                            style={isMobileMenuOpen ? { display: 'block' } : {}}
+                        >
                             {/* Search */}
-                            <div className="search-container mx-lg-4 flex-grow-1" data-aos="fade-down" data-aos-delay="100">
+                            <div className="search-container mx-lg-4 flex-grow-1">
                                 <form action="/questions" method="get">
                                     <div className="input-group nav-search-group">
                                         <span className="input-group-text bg-transparent border-0">
@@ -62,16 +97,16 @@ export default function Header() {
                                 {/* Mobile Links */}
                                 <li className="nav-item d-lg-none border-bottom pb-2 mb-2 w-100">
                                     <div className="nav-mobile-links">
-                                        <Link href="/" className="nav-link-mobile mb-2 d-block text-white">
+                                        <Link href="/" className="nav-link-mobile mb-2 d-block text-white" onClick={() => setIsMobileMenuOpen(false)}>
                                             <i className="bi bi-house-door me-2"></i> Home
                                         </Link>
-                                        <Link href="/questions" className="nav-link-mobile mb-2 d-block text-white">
+                                        <Link href="/questions" className="nav-link-mobile mb-2 d-block text-white" onClick={() => setIsMobileMenuOpen(false)}>
                                             <i className="bi bi-question-circle me-2"></i> Questions
                                         </Link>
-                                        <Link href="/tags" className="nav-link-mobile mb-2 d-block text-white">
+                                        <Link href="/tags" className="nav-link-mobile mb-2 d-block text-white" onClick={() => setIsMobileMenuOpen(false)}>
                                             <i className="bi bi-tags me-2"></i> Tags
                                         </Link>
-                                        <Link href="/users" className="nav-link-mobile mb-2 d-block text-white">
+                                        <Link href="/users" className="nav-link-mobile mb-2 d-block text-white" onClick={() => setIsMobileMenuOpen(false)}>
                                             <i className="bi bi-people me-2"></i> Users
                                         </Link>
                                     </div>
@@ -93,14 +128,14 @@ export default function Header() {
                                 ) : user ? (
                                     <>
                                         {/* Saved Items */}
-                                        <li className="nav-item mx-1" data-aos="fade-left" data-aos-delay="200">
+                                        <li className="nav-item mx-1">
                                             <Link href="/saved" className="nav-link d-flex align-items-center p-2 nav-icon-btn" title="Saved items">
                                                 <i className="bi bi-bookmark fs-5"></i>
                                             </Link>
                                         </li>
 
                                         {/* Notifications with badge */}
-                                        <li className="nav-item mx-1 position-relative" data-aos="fade-left" data-aos-delay="250">
+                                        <li className="nav-item mx-1 position-relative">
                                             <Link href="/notifications" className="nav-link d-flex align-items-center p-2 nav-icon-btn" title="Notifications">
                                                 <i className="bi bi-bell fs-5"></i>
                                                 {unreadCount > 0 && (
@@ -112,15 +147,19 @@ export default function Header() {
                                         </li>
 
                                         {/* Chat */}
-                                        <li className="nav-item mx-1" data-aos="fade-left" data-aos-delay="300">
+                                        <li className="nav-item mx-1">
                                             <Link href="/chat" className="nav-link d-flex align-items-center p-2 nav-icon-btn" title="Messages">
                                                 <i className="bi bi-chat fs-5"></i>
                                             </Link>
                                         </li>
 
-                                        {/* User Dropdown */}
-                                        <li className="nav-item dropdown mx-1" data-aos="fade-left" data-aos-delay="350">
-                                            <a className="nav-link dropdown-toggle d-flex align-items-center p-2" href="#" role="button" data-bs-toggle="dropdown">
+                                        {/* User Dropdown - React controlled */}
+                                        <li className="nav-item dropdown mx-1" ref={dropdownRef}>
+                                            <button
+                                                className="nav-link d-flex align-items-center p-2 bg-transparent border-0"
+                                                onClick={() => setIsProfileDropdownOpen(!isProfileDropdownOpen)}
+                                                aria-expanded={isProfileDropdownOpen}
+                                            >
                                                 <img
                                                     src={user.profilePicture || '/images/default-avatar.png'}
                                                     className="rounded-circle"
@@ -128,17 +167,18 @@ export default function Header() {
                                                     height="32"
                                                     alt="Profile"
                                                 />
-                                            </a>
-                                            <ul className="dropdown-menu dropdown-menu-end">
+                                            </button>
+                                            <ul className={`dropdown-menu dropdown-menu-end ${isProfileDropdownOpen ? 'show' : ''}`}
+                                                style={isProfileDropdownOpen ? { display: 'block', position: 'absolute', right: 0 } : {}}>
                                                 <li className="px-3 py-2 border-bottom">
                                                     <div className="fw-bold">{user.displayName || user.username}</div>
                                                     <small className="text-muted">@{user.username}</small>
                                                 </li>
-                                                <li><Link href="/profile" className="dropdown-item"><i className="bi bi-person me-2"></i>Profile</Link></li>
-                                                <li><Link href="/settings" className="dropdown-item"><i className="bi bi-gear me-2"></i>Settings</Link></li>
+                                                <li><Link href="/profile" className="dropdown-item" onClick={() => setIsProfileDropdownOpen(false)}><i className="bi bi-person me-2"></i>Profile</Link></li>
+                                                <li><Link href="/settings" className="dropdown-item" onClick={() => setIsProfileDropdownOpen(false)}><i className="bi bi-gear me-2"></i>Settings</Link></li>
                                                 <li><hr className="dropdown-divider" /></li>
                                                 <li>
-                                                    <button onClick={logout} className="dropdown-item text-danger">
+                                                    <button onClick={() => { setIsProfileDropdownOpen(false); logout(); }} className="dropdown-item text-danger">
                                                         <i className="bi bi-box-arrow-right me-2"></i>Sign out
                                                     </button>
                                                 </li>
@@ -147,13 +187,13 @@ export default function Header() {
                                     </>
                                 ) : (
                                     <>
-                                        <li className="nav-item mx-1" data-aos="fade-left" data-aos-delay="200">
-                                            <Link href="/login" className="btn btn-sign-in rounded-pill px-3">
+                                        <li className="nav-item mx-1">
+                                            <Link href="/auth?mode=login" className="btn btn-sign-in rounded-pill px-3">
                                                 Log in
                                             </Link>
                                         </li>
-                                        <li className="nav-item mx-1" data-aos="fade-left" data-aos-delay="250">
-                                            <Link href="/register" className="btn btn-sign-up rounded-pill px-3">
+                                        <li className="nav-item mx-1">
+                                            <Link href="/auth?mode=register" className="btn btn-sign-up rounded-pill px-3">
                                                 Sign up
                                             </Link>
                                         </li>


### PR DESCRIPTION
BUG-001 (Critical): Mobile navigation was completely broken because Header.tsx relied on Bootstrap JS (data-bs-toggle/collapse) which was not loaded. Users on mobile had no way to access navigation.

Changes:
- Replace data-bs-toggle collapse with React useState (isMobileMenuOpen)
- Replace data-bs-toggle dropdown with React useState (isProfileDropdownOpen)
- Add click-outside handler to close profile dropdown
- Add resize listener to close mobile menu on desktop
- Fix Login/Register links to use /auth?mode=login|register
- Mobile nav links now close menu on click