### PR TITLE
fix(chat): align SignalR hub broadcast fields with frontend types

### DIFF
--- a/backend/src/SocialTechsy.SocialNetwork.Api/Hubs/ChatHub.cs
+++ b/backend/src/SocialTechsy.SocialNetwork.Api/Hubs/ChatHub.cs
@@ -136,11 +136,12 @@ public class ChatHub : Hub
             {
                 messageId = savedMessage.MessageId,
                 conversationId = savedMessage.ConversationId,
-                senderId = savedMessage.SenderId, // int, not string
-                senderName = sender?.DisplayName ?? sender?.Username ?? "Unknown",
-                senderAvatar = sender?.ProfilePicture,
+                senderId = savedMessage.SenderId,
+                senderUsername = sender?.Username ?? "Unknown",
+                senderProfilePicture = sender?.ProfilePicture,
                 content = savedMessage.Content,
-                sentAt = savedMessage.SentDate.ToString("o"), // ISO 8601 format
+                messageType = savedMessage.MessageType ?? "text",
+                sentDate = savedMessage.SentDate.ToString("o"),
                 isRead = savedMessage.IsRead,
                 replyToMessageId = savedMessage.ReplyToMessageId,
                 replyToMessage = replyToDto
@@ -241,20 +242,20 @@ public class ChatHub : Hub
                 }
             }
 
-            // Prepare message DTO for broadcast
+            // Prepare message DTO for broadcast (matching frontend ChatMessage interface)
             var messageDto = new
             {
                 messageId = savedMessage.MessageId,
                 conversationId = savedMessage.ConversationId,
                 senderId = savedMessage.SenderId,
-                senderName = sender?.DisplayName ?? sender?.Username ?? "Unknown",
-                senderAvatar = sender?.ProfilePicture,
+                senderUsername = sender?.Username ?? "Unknown",
+                senderProfilePicture = sender?.ProfilePicture,
                 content = savedMessage.Content,
                 messageType = savedMessage.MessageType,
                 attachmentUrl = savedMessage.AttachmentUrl,
                 attachmentFileName = savedMessage.AttachmentFileName,
                 attachmentSize = savedMessage.AttachmentSize,
-                sentAt = savedMessage.SentDate.ToString("o"),
+                sentDate = savedMessage.SentDate.ToString("o"),
                 isRead = savedMessage.IsRead,
                 replyToMessageId = savedMessage.ReplyToMessageId,
                 replyToMessage = replyToDto

--- a/frontend/src/components/ChatWidget.tsx
+++ b/frontend/src/components/ChatWidget.tsx
@@ -32,8 +32,8 @@ interface Conversation {
     conversationId: number;
     title?: string;
     participants: Participant[];
-    lastMessage?: string;
-    lastActivityAt: string;
+    lastMessagePreview?: string;
+    lastMessageDate?: string;
     unreadCount: number;
 }
 
@@ -41,10 +41,10 @@ interface ChatMessage {
     messageId: number | string;
     conversationId: number;
     senderId: number;
-    senderName?: string;
-    senderAvatar?: string;
+    senderUsername?: string;
+    senderProfilePicture?: string;
     content: string;
-    sentAt: string;
+    sentDate: string;
     isRead: boolean;
     status?: 'sending' | 'sent' | 'delivered' | 'read';
 }
@@ -385,9 +385,11 @@ export default function ChatWidget() {
         try {
             setIsLoading(true);
             const response = await apiClient.get('/chat/conversations');
-            const convs = response.data || [];
-            setConversations(Array.isArray(convs) ? convs : []);
-            const unread = convs.reduce((acc: number, c: Conversation) => acc + (c.unreadCount || 0), 0);
+            // API returns paginated response: { items: [...], totalCount, page, pageSize }
+            const convs = response.data?.items || response.data || [];
+            const convList = Array.isArray(convs) ? convs : [];
+            setConversations(convList);
+            const unread = convList.reduce((acc: number, c: Conversation) => acc + (c.unreadCount || 0), 0);
             setTotalUnread(unread);
         } catch (error) {
             console.error('Failed to fetch conversations:', error);
@@ -430,7 +432,7 @@ export default function ChatWidget() {
             conversationId: selectedConversation.conversationId,
             senderId: user!.userId,
             content,
-            sentAt: new Date().toISOString(),
+            sentDate: new Date().toISOString(),
             isRead: false,
             status: 'sending'
         };
@@ -633,8 +635,8 @@ export default function ChatWidget() {
         
         // Check time gap (5 minutes)
         const TIME_GAP = 5 * 60 * 1000;
-        const prevTimeDiff = prevMsg ? new Date(msg.sentAt).getTime() - new Date(prevMsg.sentAt).getTime() : Infinity;
-        const nextTimeDiff = nextMsg ? new Date(nextMsg.sentAt).getTime() - new Date(msg.sentAt).getTime() : Infinity;
+        const prevTimeDiff = prevMsg ? new Date(msg.sentDate).getTime() - new Date(prevMsg.sentDate).getTime() : Infinity;
+        const nextTimeDiff = nextMsg ? new Date(nextMsg.sentDate).getTime() - new Date(msg.sentDate).getTime() : Infinity;
         
         const groupWithPrev = sameSenderAsPrev && prevTimeDiff < TIME_GAP;
         const groupWithNext = sameSenderAsNext && nextTimeDiff < TIME_GAP;
@@ -736,10 +738,10 @@ export default function ChatWidget() {
                                                 <div className="chat-widget-conv-info">
                                                     <div className="d-flex justify-content-between align-items-center">
                                                         <span className="fw-semibold small">{getParticipantName(conv)}</span>
-                                                        <span className="text-muted" style={{ fontSize: '10px' }}>{formatTime(conv.lastActivityAt)}</span>
+                                                        <span className="text-muted" style={{ fontSize: '10px' }}>{formatTime(conv.lastMessageDate || '')}</span>
                                                     </div>
                                                     <div className="d-flex align-items-center">
-                                                        <p className="text-muted small mb-0 text-truncate flex-grow-1">{conv.lastMessage || 'Start chatting...'}</p>
+                                                        <p className="text-muted small mb-0 text-truncate flex-grow-1">{conv.lastMessagePreview || 'Start chatting...'}</p>
                                                         {isParticipantOnline(conv) && (
                                                             <span className="online-text ms-1">Online</span>
                                                         )}
@@ -777,7 +779,7 @@ export default function ChatWidget() {
                                                         {!isSent && (
                                                             <div style={{ width: '28px', height: '28px', visibility: showAvatar ? 'visible' : 'hidden' }}>
                                                                 <img 
-                                                                    src={msg.senderAvatar || '/images/default-avatar.png'} 
+                                                                    src={msg.senderProfilePicture || '/images/default-avatar.png'} 
                                                                     alt="" 
                                                                     className="chat-widget-msg-avatar" 
                                                                 />
@@ -787,7 +789,7 @@ export default function ChatWidget() {
                                                             <p className="mb-0">{msg.content}</p>
                                                             {showTime && (
                                                                 <span className="chat-widget-time">
-                                                                    {formatTime(msg.sentAt)}
+                                                                    {formatTime(msg.sentDate)}
                                                                     {isSent && (
                                                                         <span className={`ms-1 status-icon ${msg.status === 'read' ? 'read' : ''}`}>
                                                                             {getMessageStatusIcon(msg.status)}


### PR DESCRIPTION
Vấn đề: Hệ thống chat real-time có 5 lỗi nghiêm trọng:
- Message history không load khi mở conversation
- Messages chỉ hiện sau khi gửi tin nhắn mới
- Messages biến mất sau khi refresh trang
- ChatWidget không load conversations

Root cause: Field name mismatch giữa SignalR hub broadcast và frontend types. ChatHub sử dụng sentAt/senderName/senderAvatar nhưng frontend mong đợi sentDate/senderUsername/senderProfilePicture (theo MessageDto).

Giải pháp:
- ChatHub.cs: Sửa anonymous objects trong SendMessage và SendMediaMessage để match MessageDto (sentDate, senderUsername, senderProfilePicture, messageType)
- ChatWidget.tsx: Align local types với shared types (types/index.ts) và fix fetchConversations xử lý paginated response

Tested: Backend build 0 errors, frontend tsc 0 errors, browser test OK