### PR TITLE
Phase 3: Server-side typing throttle with TTL auto-expire

### DIFF
--- a/backend/src/SocialTechsy.SocialNetwork.Api/Hubs/ChatHub.cs
+++ b/backend/src/SocialTechsy.SocialNetwork.Api/Hubs/ChatHub.cs
@@ -14,16 +14,21 @@ public class ChatHub : Hub
 {
     private const int MaxMessageLength = 10_000;
     private const int MaxMessagesPerMinute = 30;
+    private static readonly TimeSpan TypingThrottleWindow = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan TypingTtl = TimeSpan.FromSeconds(5);
 
     private readonly IMediator _mediator;
     private readonly ILogger<ChatHub> _logger;
     private readonly RedisChatRateLimiter? _rateLimiter;
+    private readonly RedisChatCacheService? _chatCache;
 
-    public ChatHub(IMediator mediator, ILogger<ChatHub> logger, RedisChatRateLimiter? rateLimiter = null)
+    public ChatHub(IMediator mediator, ILogger<ChatHub> logger,
+        RedisChatRateLimiter? rateLimiter = null, RedisChatCacheService? chatCache = null)
     {
         _mediator = mediator;
         _logger = logger;
         _rateLimiter = rateLimiter;
+        _chatCache = chatCache;
     }
 
     private int GetCurrentUserId() =>

--- a/backend/src/SocialTechsy.SocialNetwork.Infrastructure/Redis/RedisChatCacheService.cs
+++ b/backend/src/SocialTechsy.SocialNetwork.Infrastructure/Redis/RedisChatCacheService.cs
@@ -155,4 +155,28 @@ public class RedisChatCacheService
         var val = await _db.StringGetAsync($"chat:unread:{userId}:{conversationId}");
         return val.HasValue ? (long)val : 0;
     }
+
+    // ========== TYPING INDICATOR THROTTLE + TTL ==========
+
+    /// <summary>
+    /// Returns true if the throttle key was set (i.e. event should be broadcast).
+    /// Returns false if the key already exists (throttled, skip broadcast).
+    /// </summary>
+    public async Task<bool> SetTypingThrottleAsync(int userId, int conversationId, TimeSpan window)
+    {
+        var key = $"chat:typing:throttle:{userId}:{conversationId}";
+        return await _db.StringSetAsync(key, "1", window, when: When.NotExists);
+    }
+
+    public async Task SetTypingAsync(int userId, int conversationId, TimeSpan ttl)
+    {
+        var key = $"chat:typing:active:{userId}:{conversationId}";
+        await _db.StringSetAsync(key, "1", ttl);
+    }
+
+    public async Task ClearTypingAsync(int userId, int conversationId)
+    {
+        await _db.KeyDeleteAsync($"chat:typing:active:{userId}:{conversationId}");
+        await _db.KeyDeleteAsync($"chat:typing:throttle:{userId}:{conversationId}");
+    }
 }


### PR DESCRIPTION
## Summary
- Add 3-second server-side throttle using Redis SET NX EX
- Add 5-second TTL auto-expire for typing state
- Client no longer needs to send isTyping=false

## Test plan
- [ ] Verify throttle limits typing broadcasts to 1 per 3s
- [ ] Verify typing auto-expires after 5 seconds