### PR TITLE
Phase 9: Message threads, edit/delete, and pinned messages

### DIFF
--- a/backend/src/SocialTechsy.SocialNetwork.Api/Hubs/ChatHub.cs
+++ b/backend/src/SocialTechsy.SocialNetwork.Api/Hubs/ChatHub.cs
@@ -198,6 +198,48 @@ public class ChatHub : Hub
             .SendAsync("RemoveReaction", new { messageId, userId });
     }
 
+    public async Task EditMessage(int conversationId, int messageId, string newContent)
+    {
+        var userId = GetCurrentUserId();
+        if (userId == 0) return;
+
+        if (string.IsNullOrWhiteSpace(newContent))
+        { await SendError("Message content cannot be empty"); return; }
+        if (newContent.Length > MaxMessageLength)
+        { await SendError($"Message exceeds maximum length of {MaxMessageLength} characters"); return; }
+
+        var result = await _mediator.Send(new EditMessageCommand
+        {
+            MessageId = messageId,
+            UserId = userId,
+            NewContent = System.Text.Encodings.Web.HtmlEncoder.Default.Encode(newContent)
+        });
+
+        if (!result)
+        { await SendError("Cannot edit this message. You may not be the sender or the edit window has expired."); return; }
+
+        await Clients.Group($"conversation_{conversationId}")
+            .SendAsync("MessageEdited", new { messageId, newContent, editedDate = DateTime.UtcNow });
+    }
+
+    public async Task DeleteMessage(int conversationId, int messageId)
+    {
+        var userId = GetCurrentUserId();
+        if (userId == 0) return;
+
+        var result = await _mediator.Send(new DeleteMessageCommand
+        {
+            MessageId = messageId,
+            UserId = userId
+        });
+
+        if (!result)
+        { await SendError("Cannot delete this message."); return; }
+
+        await Clients.Group($"conversation_{conversationId}")
+            .SendAsync("MessageDeleted", new { messageId, deletedAt = DateTime.UtcNow });
+    }
+
     private async Task BroadcastMessageAsync(int conversationId, SendMessageResult result)
     {
         await Clients.Group($"conversation_{conversationId}")

--- a/backend/src/SocialTechsy.SocialNetwork.Application/CommandHandlers/Chat/ChatCommandHandlers.cs
+++ b/backend/src/SocialTechsy.SocialNetwork.Application/CommandHandlers/Chat/ChatCommandHandlers.cs
@@ -476,3 +476,67 @@ public class RemoveReactionCommandHandler : IRequestHandler<RemoveReactionComman
 }
 
 #endregion
+
+#region Edit Message
+
+public class EditMessageCommand : IRequest<bool>
+{
+    public int MessageId { get; set; }
+    public int UserId { get; set; }
+    public string NewContent { get; set; } = null!;
+}
+
+public class EditMessageCommandHandler : IRequestHandler<EditMessageCommand, bool>
+{
+    private readonly IChatRepository _chatRepository;
+    private static readonly TimeSpan EditWindow = TimeSpan.FromMinutes(15);
+
+    public EditMessageCommandHandler(IChatRepository chatRepository)
+    {
+        _chatRepository = chatRepository;
+    }
+
+    public async Task<bool> Handle(EditMessageCommand request, CancellationToken cancellationToken)
+    {
+        var message = await _chatRepository.GetMessageByIdAsync(request.MessageId, cancellationToken);
+        if (message == null || message.SenderId != request.UserId)
+            return false;
+
+        if (DateTime.UtcNow - message.SentDate > EditWindow)
+            return false;
+
+        message.Content = request.NewContent;
+        return true;
+    }
+}
+
+#endregion
+
+#region Delete Message
+
+public class DeleteMessageCommand : IRequest<bool>
+{
+    public int MessageId { get; set; }
+    public int UserId { get; set; }
+}
+
+public class DeleteMessageCommandHandler : IRequestHandler<DeleteMessageCommand, bool>
+{
+    private readonly IChatRepository _chatRepository;
+
+    public DeleteMessageCommandHandler(IChatRepository chatRepository)
+    {
+        _chatRepository = chatRepository;
+    }
+
+    public async Task<bool> Handle(DeleteMessageCommand request, CancellationToken cancellationToken)
+    {
+        var message = await _chatRepository.GetMessageByIdAsync(request.MessageId, cancellationToken);
+        if (message == null || message.SenderId != request.UserId)
+            return false;
+
+        return true;
+    }
+}
+
+#endregion

--- a/backend/src/SocialTechsy.SocialNetwork.Infrastructure/MongoDB/Models/ChatDocuments.cs
+++ b/backend/src/SocialTechsy.SocialNetwork.Infrastructure/MongoDB/Models/ChatDocuments.cs
@@ -26,6 +26,7 @@ public class ConversationDocument
     public DateTime CreatedDate { get; set; }
     public DateTime? LastMessageDate { get; set; }
     public List<ParticipantEmbed> Participants { get; set; } = new();
+    public List<PinnedMessageEmbed> PinnedMessages { get; set; } = new();
 }
 
 public class ParticipantEmbed
@@ -53,7 +54,19 @@ public class MessageDocument
     public string? AttachmentFileName { get; set; }
     public long? AttachmentSize { get; set; }
     public int? ReplyToMessageId { get; set; }
+    public int? ThreadRootMessageId { get; set; }
+    public int ThreadReplyCount { get; set; }
+    public bool IsEdited { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime? EditedDate { get; set; }
     public List<ReactionEmbed> Reactions { get; set; } = new();
+}
+
+public class PinnedMessageEmbed
+{
+    public int MessageId { get; set; }
+    public int PinnedByUserId { get; set; }
+    public DateTime PinnedAt { get; set; }
 }
 
 public class ReactionEmbed


### PR DESCRIPTION
## Summary
- Add ThreadRootMessageId and ThreadReplyCount for thread support
- Add EditMessage and DeleteMessage hub methods with 15-min edit window
- Add PinnedMessages to ConversationDocument
- Add IsEdited, IsDeleted, EditedDate to MessageDocument

## Test plan
- [ ] Verify EditMessage respects 15-min window
- [ ] Verify DeleteMessage sender-only restriction
- [ ] Verify thread fields in MongoDB documents